### PR TITLE
Update vol.py

### DIFF
--- a/finance_ml/stats/vol.py
+++ b/finance_ml/stats/vol.py
@@ -14,8 +14,7 @@ def _get_ret(close, span=100, days=None, seconds=None):
     # Get rid of duplications in index
     prev_idx = prev_idx.drop_duplicates()
     ret = close[prev_idx.index] / close[prev_idx].values - 1
-    vol = ret.ewm(span=span).std()
-    return vol
+    return ret
 
 
 def get_vol(close, span=100, days=None, seconds=None):


### PR DESCRIPTION
.ewm() is repeated twice in each of the functions get_vol() and get_mean() due to the method being called both in the main functions and helper function.